### PR TITLE
Hotfix/Login Button

### DIFF
--- a/frontend/src/auth_config.json
+++ b/frontend/src/auth_config.json
@@ -1,4 +1,5 @@
 {
     "domain": "rota-flex-101.eu.auth0.com",
-    "clientId": "NqmZExdF9Q14mgi7p5o5RkPt338B2irO"
+    "clientId": "NqmZExdF9Q14mgi7p5o5RkPt338B2irO",
+    "callbackUri": "http://localhost:3000/callback"
   }

--- a/frontend/src/auth_config.json
+++ b/frontend/src/auth_config.json
@@ -1,5 +1,5 @@
 {
-    "domain": "rota-flex-101.eu.auth0.com",
-    "clientId": "NqmZExdF9Q14mgi7p5o5RkPt338B2irO",
-    "callbackUri": "http://localhost:3000/callback"
-  }
+  "domain": "rota-flex-101.eu.auth0.com",
+  "clientId": "NqmZExdF9Q14mgi7p5o5RkPt338B2irO",
+  "callbackUri": "http://localhost:3000/callback"
+}

--- a/frontend/src/components/home/index.tsx
+++ b/frontend/src/components/home/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Redirect, BrowserRouter as Router } from 'react-router-dom';
+import { Route, BrowserRouter as Router } from 'react-router-dom';
 import Sidebar from '../sidebar';
 import Employees from '../employees';
 import Rota from '../rota';
@@ -14,9 +14,6 @@ const Home = () => (
       <Route path="/summary" component={Summary} />
       <Route path="/" component={Sidebar} />
     </div>
-    <Route exact path="/">
-      <Redirect to="/employees" />
-    </Route>
   </Router>
 );
 

--- a/frontend/src/components/home/index.tsx
+++ b/frontend/src/components/home/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, BrowserRouter as Router } from 'react-router-dom';
+import { Route, Redirect } from 'react-router-dom';
 import Sidebar from '../sidebar';
 import Employees from '../employees';
 import Rota from '../rota';
@@ -7,14 +7,17 @@ import Summary from '../summary';
 import homeStyles from './home.module.scss';
 
 const Home = () => (
-  <Router>
+  <>
     <div className={homeStyles.home}>
       <Route path="/employees" component={Employees} />
       <Route path="/rota" component={Rota} />
       <Route path="/summary" component={Summary} />
       <Route path="/" component={Sidebar} />
     </div>
-  </Router>
+    <Route exact path="/">
+      <Redirect to="/employees" />
+    </Route>
+  </>
 );
 
 export default Home;

--- a/frontend/src/components/loginOutButton/index.tsx
+++ b/frontend/src/components/loginOutButton/index.tsx
@@ -17,7 +17,7 @@ const LoginOutButton = () => {
     if (isAuthenticated) {
       logout({ federated: true });
     } else {
-      loginWithRedirect({});
+      loginWithRedirect({ appState: { targetUrl: window.location.pathname } });
     }
   };
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { RedirectLoginResult } from '@auth0/auth0-spa-js';
+import { Router } from 'react-router-dom';
 import { Auth0Provider } from './react-auth0-spa';
 import App from './components/app';
 import config from './auth_config.json';
@@ -29,9 +30,11 @@ ReactDOM.render(
       <Auth0Provider
         domain={config.domain}
         client_id={config.clientId}
-        redirect_uri={window.location.origin}
+        redirect_uri="http://localhost:3000/callback"
         onRedirectCallback={onRedirectCallback}>
-        <App />
+        <Router history={history}>
+          <App />
+        </Router>
       </Auth0Provider>
     </Provider>
   </React.StrictMode>,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -30,7 +30,7 @@ ReactDOM.render(
       <Auth0Provider
         domain={config.domain}
         client_id={config.clientId}
-        redirect_uri="http://localhost:3000/callback"
+        redirect_uri={config.callbackUri}
         onRedirectCallback={onRedirectCallback}>
         <Router history={history}>
           <App />


### PR DESCRIPTION
## Hotfix
Login button does not work in current master branch. This pull request fixes it and updates its behaviour to work as expected:
- When you log in, you are redirected to the Route you logged in from
- The `/` route still redirects without causing login issues

### Issue

This bit of code is causing issues with Auth0:

```
<Route exact path="/">
  <Redirect to="/employees" />
</Route>
```

The issue was that the original `callback_uri` was`http://localhost:3000`, but when that route was reached you were instantly redirected to `/employees`. To fix this, I updated the `callback_uri` to `http://localhost:3000/callback` which is a standard way to handle this.

This then caused the issue that the user would be returned to `http://localhost:3000` by default after login, which would then always try and redirect to `/employees` again. 

To fix this, `BrowserRouter` was replaced with `Router`. This is required so that the custom `history` object can be used for routing. The custom history object is passed to the `Router` as a prop and it then allows `onRedirectCallback()` in `index.tsx` to push the `targetUrl` defined by the login button to the history object, which automatically navigates to the page that you logged in from.