### PR TITLE
Feature/34 Update staff endpoint with ExceptionHandler

### DIFF
--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -132,10 +133,10 @@ public class StaffController {
    * @param updatedStaff Updated staff information.
    * @return The updated {@link Staff} member.
    */
-  @PutMapping("/staff/$id")
+  @PutMapping("/staff/{id}")
   @ApiOperation(value = "Lets an authenticated manager update a staff member")
   public Staff updateStaff(
-      @RequestParam
+      @PathVariable
       @ApiParam(value = "Staff ID")
           int id,
       @RequestBody

--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -8,11 +8,9 @@ import com.rota.database.orm.staff.Staff;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-
 import java.time.Instant;
 import java.util.List;
 import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -85,8 +83,9 @@ public class StaffController {
   /**
    * Endpoint to create and enter a new staff record into the system.
    * Staff ID and role is inferred from the token passed in the header's Authorization field.
+   *
    * @param authString Authentication token.
-   * @param staffDto Staff details.
+   * @param staffDto   Staff details.
    * @return The created staff object as a JsonResponse.
    */
   @PostMapping("/staff/create")
@@ -111,6 +110,7 @@ public class StaffController {
 
   /**
    * Get endpoint for all active staff members.
+   *
    * @param authString Authentication token.
    * @return List of all active staff members.
    */
@@ -126,22 +126,43 @@ public class StaffController {
   }
 
   /**
+   * Endpoint to update the information of a staff member.
+   *
+   * @param id           The ID of the staff member to be updated.
+   * @param updatedStaff Updated staff information.
+   * @return The updated {@link Staff} member.
+   */
+  @PutMapping("/staff/$id")
+  @ApiOperation(value = "Lets an authenticated manager update a staff member")
+  public Staff updateStaff(
+      @RequestParam
+      @ApiParam(value = "Staff ID")
+          int id,
+      @RequestBody
+      @ApiParam(value = "Updated staff object")
+          StaffDto updatedStaff
+  ) {
+    verifyManagementRole("auth");
+    return staffService.updateStaff(id, updatedStaff);
+  }
+
+  /**
    * Endpoint for the manager to remove a staff member by a given id.
-   * 
+   *
    * @param authString manager's authentication token.
-   * @param id staff id to remove.
+   * @param id         staff id to remove.
    * @return An updated list of active staff members.
    */
   @PutMapping("/staff/remove")
   @ApiOperation(value = "Allows manager to remove a user with a given id and returns "
       + "an updated list of active users")
   public List<Staff> removeStaffMember(
-      @RequestHeader(AUTHORIZATION_HEADER) 
-      @ApiParam(value = "Authentication token") 
-      String authString,
+      @RequestHeader(AUTHORIZATION_HEADER)
+      @ApiParam(value = "Authentication token")
+          String authString,
 
-      @RequestParam(name = "id", required = true) 
-      int id
+      @RequestParam(name = "id", required = true)
+          int id
   ) {
     verifyManagementRole(authString);
     staffService.removeStaff(id);

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -1,17 +1,17 @@
 package com.rota.api;
 
 import com.rota.api.dto.EngagementDto;
+import com.rota.api.dto.StaffDto;
 import com.rota.auth.AuthenticationUtils;
 import com.rota.database.orm.engagement.EngagementRepository;
 import com.rota.database.orm.staff.Role;
 import com.rota.database.orm.staff.Staff;
 import com.rota.database.orm.staff.StaffRepository;
-
+import com.rota.exceptions.StaffNotFoundException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -84,7 +84,7 @@ public class StaffService {
 
   /**
    * Deactivates staff member with given id.
-   * 
+   *
    * @param id ID of staff member to deactivate
    */
   public void removeStaff(int id) {
@@ -93,5 +93,21 @@ public class StaffService {
       staff.setInactive(true);
       staffRepository.save(staff);
     });
+  }
+
+  /**
+   * Updates a staff member in the database.
+   *
+   * @param id           Of the staff member being updated.
+   * @param updatedStaff Updated staff details.
+   * @return The updated {@link Staff} member.
+   */
+  public Staff updateStaff(int id, StaffDto updatedStaff) {
+    // Check to see if that staff member exists, throw exception if not.
+    staffRepository.findById(id).orElseThrow(StaffNotFoundException::new);
+    // If it exists, safe new staff information to that ID.
+    Staff staffToSave = updatedStaff.toStaff();
+    staffToSave.setId(id);
+    return staffRepository.save(staffToSave);
   }
 }

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -104,7 +104,7 @@ public class StaffService {
    */
   public Staff updateStaff(int id, StaffDto updatedStaff) {
     // Check to see if that staff member exists, throw exception if not.
-    staffRepository.findById(id).orElseThrow(StaffNotFoundException::new);
+    staffRepository.findById(id).orElseThrow(() -> new StaffNotFoundException(id));
     // If it exists, safe new staff information to that ID.
     Staff staffToSave = updatedStaff.toStaff();
     staffToSave.setId(id);

--- a/backend/src/main/java/com/rota/exceptions/ControllerExceptionHandler.java
+++ b/backend/src/main/java/com/rota/exceptions/ControllerExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.rota.exceptions;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+  /**
+   * Handles StaffNotFoundException.
+   *
+   * @param e                  The exception.
+   * @param httpServletRequest the request that caused the exception.
+   * @return An {@link ErrorResponse} in response.
+   */
+  @ExceptionHandler(StaffNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleStaffNotFoundException(
+      StaffNotFoundException e,
+      HttpServletRequest httpServletRequest
+  ) {
+    return new ResponseEntity<>(
+        new ErrorResponse(
+            HttpStatus.BAD_REQUEST,
+            e.getMessage(),
+            httpServletRequest.getServletPath()),
+        HttpStatus.BAD_REQUEST);
+  }
+}

--- a/backend/src/main/java/com/rota/exceptions/ErrorResponse.java
+++ b/backend/src/main/java/com/rota/exceptions/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.rota.exceptions;
+
+import java.time.Instant;
+import lombok.Value;
+import org.springframework.http.HttpStatus;
+
+@Value
+public class ErrorResponse {
+  int status;
+  String error;
+  String message;
+  String path;
+  Instant timestamp;
+
+  /**
+   * Error response constructor, used by ControllerExceptionHandler.
+   *
+   * @param httpStatus The status code to send.
+   * @param message    A useful error message.
+   * @param path       The path where the exception happened.
+   */
+  public ErrorResponse(HttpStatus httpStatus, String message, String path) {
+    this.status = httpStatus.value();
+    this.error = httpStatus.getReasonPhrase();
+    this.timestamp = Instant.now();
+    this.message = message;
+    this.path = path;
+  }
+}
+

--- a/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
+++ b/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
@@ -1,0 +1,7 @@
+package com.rota.exceptions;
+
+public class StaffNotFoundException extends RuntimeException {
+  public StaffNotFoundException() {
+    super();
+  }
+}

--- a/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
+++ b/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
@@ -1,7 +1,7 @@
 package com.rota.exceptions;
 
 public class StaffNotFoundException extends RuntimeException {
-  public StaffNotFoundException() {
-    super();
+  public StaffNotFoundException(int id) {
+    super("Unable to find staff member with ID: " + id);
   }
 }

--- a/backend/src/test/java/com/rota/api/StaffServiceTests.java
+++ b/backend/src/test/java/com/rota/api/StaffServiceTests.java
@@ -1,0 +1,62 @@
+package com.rota.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.rota.api.dto.StaffDto;
+import com.rota.database.orm.staff.Role;
+import com.rota.database.orm.staff.Staff;
+import com.rota.database.orm.staff.StaffRepository;
+import com.rota.exceptions.StaffNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class StaffServiceTests {
+
+  @Mock
+  private StaffRepository staffRepository;
+
+  @InjectMocks
+  private StaffService staffService;
+
+  @BeforeEach
+  public void setUp() {
+    staffService = new StaffService();
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private final StaffDto validStaffDto = new StaffDto("Initial", "Test", Role.USER,
+      null, 0, 0, "", "", false);
+
+  @Test
+  public void updateStaffInvalidUserId() {
+    final int invalidUserId = 12301;
+    when(staffRepository.findById(invalidUserId)).thenThrow(new StaffNotFoundException());
+
+    assertThrows(
+        StaffNotFoundException.class, () -> staffService.updateStaff(invalidUserId, validStaffDto));
+  }
+
+  @Test
+  public void updateStaff() {
+    Staff initialStaffObject = new Staff();
+    StaffDto updatedStaffDto = new StaffDto("Updated", "User", Role.USER,
+        null, 0, 0, "", "", false);
+    Staff updatedStaffObject = updatedStaffDto.toStaff();
+
+    when(staffRepository.findById(1)).thenReturn(Optional.of(initialStaffObject));
+    when(staffRepository.save(any(Staff.class))).thenReturn(updatedStaffObject);
+
+    Staff actualResult = staffService.updateStaff(1, updatedStaffDto);
+
+    assertThat(actualResult, is(equalTo(updatedStaffObject)));
+  }
+}

--- a/backend/src/test/java/com/rota/api/StaffServiceTests.java
+++ b/backend/src/test/java/com/rota/api/StaffServiceTests.java
@@ -39,7 +39,8 @@ public class StaffServiceTests {
   @Test
   public void updateStaffInvalidUserId() {
     final int invalidUserId = 12301;
-    when(staffRepository.findById(invalidUserId)).thenThrow(new StaffNotFoundException());
+    when(staffRepository.findById(invalidUserId))
+        .thenThrow(new StaffNotFoundException(invalidUserId));
 
     assertThrows(
         StaffNotFoundException.class, () -> staffService.updateStaff(invalidUserId, validStaffDto));


### PR DESCRIPTION
## Changes
### Staff endpoint and business logic
- Added a PUT endpoint to `/staff/{id}` which is used to update the staff member with that ID with a new StaffDto object.
- Added `updateStaff()` method in `StaffService`.
  - Checks to see if a staff member with that ID is in the database.
    - If not, throw `StaffNotFoundException`.
  - If that staff member exists, convert `StaffDto` to `Staff`, and set its ID to corresponding staff ID.
  - Save in database.
- Added `updateStaff()` tests.
### ExceptionHandler
Since a custom exception is thrown in the new code, I've added an exception handler for the controller layer. In this PR, if a `StaffNotFoundException` is thrown, it creates a nice error response message to be sent to the user. In this case it sends this response when the ID isn't found when updating a staff member:

![image](https://user-images.githubusercontent.com/8884999/81298329-8de9d100-906c-11ea-96a6-f0fb083e0eeb.png)

This exception handler can be used to handle any exceptions that are thrown in the controller layer.

### Potential changes
In the `StaffController` we currently get all staff by making a GET request to `/staff/get`. Would it make more sense for it to just do GET `/staff` to return all staff? Then GET `/staff/$id` to get a specific staff member?