### PR TITLE
gitattributes file added to replace eol prettier linting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Based off of https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -5,6 +5,5 @@
   "singleQuote": true,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "jsxBracketSameLine": true,
-  "endOfLine": "lf"
+  "jsxBracketSameLine": true
 }


### PR DESCRIPTION
Having prettier format files to have linux line endings caused some issues with vscode on windows where files show up as modified when only line endings were changed. 

Configuring the settings through a .gitattribute file should make the files being committed tot he repo normalise to lf line endings for the whole repo. 

This would work for anyone checking out the repo without having to set any local git settings eg. `git config --global core.autocrlf true`.

Followed from https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings