### PR TITLE
Bug/110 job type should not be case sensitive

### DIFF
--- a/backend/src/main/java/com/rota/database/orm/staff/Staff.java
+++ b/backend/src/main/java/com/rota/database/orm/staff/Staff.java
@@ -1,7 +1,14 @@
 package com.rota.database.orm.staff;
 
 import java.time.LocalDate;
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backend/src/main/java/com/rota/database/orm/staff/Staff.java
+++ b/backend/src/main/java/com/rota/database/orm/staff/Staff.java
@@ -1,12 +1,8 @@
 package com.rota.database.orm.staff;
 
 import java.time.LocalDate;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -40,4 +36,14 @@ public class Staff {
   private String preferredDates;
 
   private String jobTitle;
+
+  @PrePersist
+  private void onPrePersist() {
+    this.setJobTitle(jobTitle.toLowerCase());
+  }
+
+  @PreUpdate
+  private void onPreUpdate() {
+    this.setJobTitle(jobTitle.toLowerCase());
+  }
 }

--- a/backend/src/test/java/com/rota/database/DbHandlerTests.java
+++ b/backend/src/test/java/com/rota/database/DbHandlerTests.java
@@ -38,7 +38,7 @@ class DbHandlerTests {
       .contractedHours(10.0)
       .hourlyRate(40.0)
       .role(Role.USER)
-      .jobTitle("Sprzatacz");
+      .jobTitle("sprzatacz");
 
   static final Staff STAFF_MEMBER = STAFF_BUILDER.build();
 
@@ -140,10 +140,11 @@ class DbHandlerTests {
 
   @Test
   void newStaffJobTitleIsLowerCase() {
-    staffRepository.save(STAFF_MEMBER);
+    Staff staff = STAFF_BUILDER.jobTitle("Server").build();
+    staffRepository.save(staff);
     Assertions.assertEquals(
-            STAFF_MEMBER.getJobTitle().toLowerCase(),
-            staffRepository.findById(STAFF_ID).get().getJobTitle()
+            staff.getJobTitle().toLowerCase(),
+            staffRepository.findById(staff.getId()).get().getJobTitle()
     );
   }
 

--- a/backend/src/test/java/com/rota/database/DbHandlerTests.java
+++ b/backend/src/test/java/com/rota/database/DbHandlerTests.java
@@ -137,4 +137,26 @@ class DbHandlerTests {
         engagementRepository.findByStaffId(STAFF_ID)
     );
   }
+
+  @Test
+  void newStaffJobTitleIsLowerCase() {
+    staffRepository.save(STAFF_MEMBER);
+    Assertions.assertEquals(
+            STAFF_MEMBER.getJobTitle().toLowerCase(),
+            staffRepository.findById(STAFF_ID).get().getJobTitle()
+    );
+  }
+
+  @Test
+  void updatedStaffJobTitleIsLowerCase() {
+    String newJobTitle = "CHEF";
+    staffRepository.save(STAFF_MEMBER);
+    Staff staff = staffRepository.findById(STAFF_ID).get();
+    staff.setJobTitle(newJobTitle);
+    staffRepository.save(staff);
+    Assertions.assertEquals(
+            newJobTitle.toLowerCase(),
+            staffRepository.findById(STAFF_ID).get().getJobTitle()
+    );
+  }
 }


### PR DESCRIPTION
This PR ensures that whenever we save/update jobTitle to the db, that it'll be converted to lower case first.

Also added tests to make sure this remains relevant.

closes #110 