### PR TITLE
Feature/37 - Get engagements between dates endpoint

### DIFF
--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -61,6 +61,28 @@ public class StaffController {
   }
 
   /**
+   * Returns shifts of all staff members.
+
+   * @param start Start time or null.
+   * @param end End time or null.
+   * @return List of all shifts between start and end times.
+   */
+  @GetMapping("/staff/shifts")
+  @ApiOperation(value = "Returns shifts of all users in a specified time frame.",
+        response = EngagementDto[].class, authorizations = {@Authorization(value = "Bearer")})
+  public List<EngagementDto> getAllShifts(
+      @RequestParam(name = "start", required = false)
+      @ApiParam(value = "start time")
+          Instant start,
+
+      @RequestParam(name = "end", required = false)
+      @ApiParam(value = "end time")
+          Instant end
+  ) {
+    return staffService.getAllEngagementsBetween(start, end);
+  }
+
+  /**
    * Endpoint to create and enter a new staff record into the system.
    * Staff ID and role is inferred from the token passed in the header's Authorization field.
    *

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -36,7 +36,8 @@ public class StaffService {
     Instant startTime = start == null ? Instant.MIN : start;
     Instant endTime = end == null ? Instant.MAX : end;
 
-    return (Engagement engagement) -> !engagement.getEnd().isBefore(startTime)
+    return (Engagement engagement) -> !endTime.isBefore(startTime)
+        && !engagement.getEnd().isBefore(startTime)
         && !engagement.getStart().isAfter(endTime);
   }
 
@@ -61,7 +62,7 @@ public class StaffService {
 
   /**
    * Returns staff member's engagements between start and end dates (inclusive).
-   * Specifically engagements that start after the start date and end before the end date.
+   * Engagements that go through start or end times are truncated.
    * Both start and end dates are optional and can be left as null.
    *
    * @param staffId Staff member's ID
@@ -79,7 +80,7 @@ public class StaffService {
 
   /**
    * Returns all engagements between start and end dates (inclusive).
-   * Specifically engagements that start after the start date and end before the end date.
+   * Engagements that go through start or end times are truncated.
    * Both start and end dates are optional and can be left as null.
    * 
    * @param start start date or null to get from the beginning

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -2,6 +2,7 @@ package com.rota.api;
 
 import com.rota.api.dto.EngagementDto;
 import com.rota.api.dto.StaffDto;
+import com.rota.database.orm.engagement.Engagement;
 import com.rota.database.orm.engagement.EngagementRepository;
 import com.rota.database.orm.staff.Staff;
 import com.rota.database.orm.staff.StaffRepository;
@@ -10,6 +11,8 @@ import com.rota.exceptions.StaffNotFoundException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -23,6 +26,40 @@ public class StaffService {
   StaffRepository staffRepository;
 
   /**
+   * Checks if the engagement has any overlap with the requested time frame.
+   * 
+   * @param start start time
+   * @param end end time
+   * @return true if engagement times have any overlap with requested times
+   */
+  private Predicate<Engagement> isEngagementBetween(Instant start, Instant end) {
+    Instant startTime = start == null ? Instant.MIN : start;
+    Instant endTime = end == null ? Instant.MAX : end;
+
+    return (Engagement engagement) -> !engagement.getEnd().isBefore(startTime)
+        && !engagement.getStart().isAfter(endTime);
+  }
+
+  /**
+   * Truncates the engagement, e.g. if if starts before the start time the function will cut off the
+   * time difference and set the engagement start time to requested start time.
+   */
+  private Function<Engagement, Engagement> truncateEngagement(Instant start, Instant end) {
+    Instant startTime = start == null ? Instant.MIN : start;
+    Instant endTime = end == null ? Instant.MAX : end;
+
+    return (Engagement engagement) -> {
+      if (engagement.getStart().isBefore(startTime)) {
+        engagement.setStart(startTime);
+      }
+      if (engagement.getEnd().isAfter(endTime)) {
+        engagement.setEnd(endTime);
+      }
+      return engagement;
+    };
+  }
+
+  /**
    * Returns staff member's engagements between start and end dates (inclusive).
    * Specifically engagements that start after the start date and end before the end date.
    * Both start and end dates are optional and can be left as null.
@@ -33,12 +70,26 @@ public class StaffService {
    * @return A list of member's engagements
    */
   public List<EngagementDto> getStaffEngagementsBetween(int staffId, Instant start, Instant end) {
-    Instant startTime = start == null ? Instant.MIN : start;
-    Instant endTime = end == null ? Instant.MAX : end;
     return engagementRepository.findByStaffId(staffId).stream()
-        .filter(engagement ->
-            !engagement.getStart().isBefore(startTime)
-                && !engagement.getEnd().isAfter(endTime))
+        .filter(isEngagementBetween(start, end))
+        .map(truncateEngagement(start, end))
+        .map(EngagementDto::fromEngagement)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns all engagements between start and end dates (inclusive).
+   * Specifically engagements that start after the start date and end before the end date.
+   * Both start and end dates are optional and can be left as null.
+   * 
+   * @param start start date or null to get from the beginning
+   * @param end end date or null to get to the end
+   * @return All engagements between the two dates
+   */
+  public List<EngagementDto> getAllEngagementsBetween(Instant start, Instant end) {
+    return engagementRepository.findAll().stream()
+        .filter(isEngagementBetween(start, end))
+        .map(truncateEngagement(start, end))
         .map(EngagementDto::fromEngagement)
         .collect(Collectors.toList());
   }

--- a/backend/src/main/java/com/rota/database/orm/engagement/EngagementRepository.java
+++ b/backend/src/main/java/com/rota/database/orm/engagement/EngagementRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface EngagementRepository extends CrudRepository<Engagement, Long> {
   List<Engagement> findByStaffId(int staffId);
 
+  List<Engagement> findAll();
+
   Engagement findById(int id);
 }

--- a/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
+++ b/backend/src/main/java/com/rota/exceptions/StaffNotFoundException.java
@@ -1,6 +1,8 @@
 package com.rota.exceptions;
 
 public class StaffNotFoundException extends RuntimeException {
+  static final long serialVersionUID = 1L;
+
   public StaffNotFoundException(int id) {
     super("Unable to find staff member with ID: " + id);
   }

--- a/backend/src/test/java/com/rota/api/EngagementTests.java
+++ b/backend/src/test/java/com/rota/api/EngagementTests.java
@@ -1,0 +1,88 @@
+package com.rota.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.rota.api.dto.EngagementDto;
+import com.rota.database.orm.engagement.Engagement;
+import com.rota.database.orm.engagement.EngagementRepository;
+import com.rota.database.orm.engagement.EngagementType;
+import com.rota.database.orm.staff.Staff;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class EngagementTests {
+
+  @Mock
+  private EngagementRepository engagementRepository;
+
+  @InjectMocks
+  private StaffService staffService;
+  
+  @BeforeEach
+  public void setUp() {
+    staffService = new StaffService();
+    MockitoAnnotations.initMocks(this);
+  }
+
+  private final Staff dummyStaff = Staff.builder()
+      .id(1).build();
+  private final Instant engagementStart = Instant.parse("2020-05-19T23:00:00Z");
+  private final Instant engagementEnd = Instant.parse("2020-05-20T01:00:00Z");
+  private final List<Engagement> exampleEngagements =
+      List.of(
+          new Engagement(
+              1,
+              engagementStart, 
+              engagementEnd,
+              EngagementType.SHIFT,
+              0,
+              dummyStaff
+          )
+      );
+  private final Instant queryTime = Instant.parse("2020-05-20T00:00:00Z");
+  
+  @Test
+  public void truncateEngagementStart() {
+    when(engagementRepository.findAll())
+      .thenReturn(exampleEngagements);
+
+    final List<EngagementDto> expectedResult = List.of(
+        new EngagementDto(
+            1,
+            queryTime, 
+            engagementEnd, 
+            EngagementType.SHIFT)
+    );
+
+    assertEquals(
+        expectedResult,
+        staffService.getAllEngagementsBetween(queryTime, null)
+    );
+  }
+  
+  @Test
+  public void truncateEngagementEnd() {
+    when(engagementRepository.findAll())
+      .thenReturn(exampleEngagements);
+
+    final List<EngagementDto> expectedResult = List.of(
+        new EngagementDto(
+            1,
+            engagementStart, 
+            queryTime, 
+            EngagementType.SHIFT)
+    );
+
+    assertEquals(
+        expectedResult,
+        staffService.getAllEngagementsBetween(null, queryTime)
+    );
+  }
+}

--- a/backend/src/test/java/com/rota/api/EngagementTests.java
+++ b/backend/src/test/java/com/rota/api/EngagementTests.java
@@ -85,4 +85,26 @@ public class EngagementTests {
         staffService.getAllEngagementsBetween(null, queryTime)
     );
   }
+
+  @Test
+  public void engagementOutsideOfQuery() {
+    when(engagementRepository.findAll())
+      .thenReturn(exampleEngagements);
+
+    assertEquals(
+        List.of(),
+        staffService.getAllEngagementsBetween(null, Instant.parse("2020-05-19T22:59:00Z"))
+    );
+  }
+
+  @Test
+  public void startDateAfterEndDate() { // Should return an empty list
+    when(engagementRepository.findAll())
+      .thenReturn(exampleEngagements);
+
+    assertEquals(
+        List.of(),
+        staffService.getAllEngagementsBetween(engagementEnd, engagementStart)
+    );
+  }
 }

--- a/backend/src/test/java/com/rota/database/DbHandlerTests.java
+++ b/backend/src/test/java/com/rota/database/DbHandlerTests.java
@@ -9,7 +9,6 @@ import com.rota.database.orm.staff.StaffRepository;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
I didn't realise this while creating the branch, but this is actually #37 .

This is needed for the pie chart.

Note that I have changed the endpoint to truncate the engagements if they cross the query time, e.g. if there is an engagement between 1pm-3pm and the query specifies the start time at 2pm, the returning engagement will be 2pm-3pm.
This will allow to calculate the times more precisely.