### PR TITLE
Feature/155 - add engagement endpoint

### DIFF
--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -3,6 +3,7 @@ package com.rota.api;
 import com.rota.api.dto.EngagementDto;
 import com.rota.api.dto.StaffDto;
 import com.rota.auth.Authentication;
+import com.rota.database.orm.engagement.EngagementType;
 import com.rota.database.orm.staff.Role;
 import com.rota.database.orm.staff.Staff;
 import com.rota.exceptions.StaffNotFoundException;
@@ -167,5 +168,19 @@ public class StaffController {
   ) {
     staffService.removeStaff(id);
     return staffService.getActiveStaff();
+  }
+
+  /**
+   * Endpoint for the manager to add staff member's engagement.
+   */
+  @PostMapping("/staff/addEngagement")
+  @ApiOperation(value = "Allows manager to add an engagement for a certain user", authorizations = {
+      @Authorization(value = "Bearer") })
+  public void addEngagement(
+      @Valid 
+      @RequestBody 
+      EngagementDto engagement
+  ) {
+    staffService.addEngagement(engagement);
   }
 }

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -95,6 +95,32 @@ public class StaffService {
         .collect(Collectors.toList());
   }
 
+  private Optional<Engagement> fromDto(EngagementDto engagement) {
+    Optional<Staff> staffOptional = staffRepository.findById(engagement.getStaffId());
+    return staffOptional.map((Staff staff) -> 
+    Engagement
+        .builder()
+        .staff(staff)
+        .start(engagement.getStart())
+        .end(engagement.getEnd())
+        .type(engagement.getType())
+        .build()
+    );
+
+  }
+
+  /**
+   * Adds an engagement to the database.
+   */
+  public void addEngagement(EngagementDto engagementDto) {
+    Optional<Engagement> engagementOptional = fromDto(engagementDto);
+    engagementOptional.ifPresentOrElse(
+        (Engagement engagement) -> engagementRepository.save(engagement),
+        () -> {
+          throw new StaffNotFoundException();
+        });
+  }
+
   /**
    * Adds a new staff entity to the database.
    *


### PR DESCRIPTION
Can add engament with
```
curl "http://localhost:8080/staff/addEngagement" -H "Authorization: BEARER $TOKEN" -X 'POST' -H 'Content-Type:application/json' -d '{"staffId":"1", "start":"2020-06-03T14:52:33Z", "end":"2020-06-03T17:00:00Z", "type":"SHIFT"}'
```
Verify with
```
curl "http://localhost:8080/staff/addEngagement" -H "Authorization: BEARER $TOKEN" -X 'POST' -H 'Content-Type:application/json' -d '{"staffId":"1", "start":"2020-06-03T14:52:33Z", "end":"2020-06-03T17:00:00Z", "type":"SHIFT"}'
```

where $TOKEN is set to the value shown in the front-end console.