### PR TITLE
CLEANUP 156 - replace Staff with StaffDto in the controller class

### DIFF
--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -16,8 +16,8 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -103,17 +103,17 @@ public class StaffController {
    * @param staffDto Staff details.
    * @return A Response entity of a {@link Staff} object.
    */
-  @PostMapping("/staff/create")
+  @PostMapping("/staff")
   @ApiOperation(value = "Lets an authenticated manager create a new staff user",
       consumes = "application/json", authorizations = {@Authorization(value = "Bearer")})
-  public ResponseEntity<Staff> createStaff(
+  public ResponseEntity<StaffDto> createStaff(
       @Valid
       @RequestBody
       @ApiParam("Staff details for the new user")
           StaffDto staffDto
   ) {
     // Assuming in general staff entered will be active ones
-    Staff createdStaff = staffService.createStaff(staffDto.toStaff());
+    StaffDto createdStaff = staffService.createStaff(staffDto);
 
     return ResponseEntity.ok().body(createdStaff);
   }
@@ -123,33 +123,29 @@ public class StaffController {
    *
    * @return List of all active staff members.
    */
-  @GetMapping("/staff/get")
+  @GetMapping("/staff")
   @ApiOperation(value = "Lets an authenticated manager view list of all active staff",
       authorizations = {@Authorization(value = "Bearer")})
-  public List<Staff> getActiveStaff() {
+  public List<StaffDto> getActiveStaff() {
     return staffService.getActiveStaff();
   }
 
   /**
    * Endpoint to update the information of a staff member.
    *
-   * @param id           The ID of the staff member to be updated.
    * @param updatedStaff Updated staff information.
    * @return The updated {@link Staff} member.
    */
-  @PutMapping("/staff/{id}")
+  @PutMapping("/staff")
   @ApiOperation(value = "Lets an authenticated manager update a staff member", authorizations = {
       @Authorization(value = "Bearer")})
-  public Staff updateStaff(
-      @PathVariable
-      @ApiParam(value = "Staff ID")
-          int id,
+  public StaffDto updateStaff(
       @Valid
       @RequestBody
       @ApiParam(value = "Updated staff object")
           StaffDto updatedStaff
   ) {
-    return staffService.updateStaff(id, updatedStaff);
+    return staffService.updateStaff(updatedStaff);
   }
 
   /**
@@ -158,10 +154,10 @@ public class StaffController {
    * @param id staff id to remove.
    * @return An updated list of active staff members.
    */
-  @PutMapping("/staff/remove")
+  @DeleteMapping("/staff")
   @ApiOperation(value = "Allows manager to remove a user with a given id and returns "
       + "an updated list of active users", authorizations = {@Authorization(value = "Bearer")})
-  public List<Staff> removeStaffMember(
+  public List<StaffDto> removeStaffMember(
       @RequestParam(name = "id", required = true)
           int id
   ) {

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -101,12 +101,12 @@ public class StaffService {
    * @param newStaff {@link Staff} to be added.
    * @return {@link Staff} object which has just been created.
    */
-  public Staff createStaff(Staff newStaff) {
+  public StaffDto createStaff(StaffDto newStaff) {
     findStaffByEmail(newStaff.getEmail()).ifPresent(
         (Staff staff) -> {
           throw new DuplicateEmailException(newStaff.getEmail());
         });
-    return staffRepository.save(newStaff);
+    return StaffDto.of(staffRepository.save(newStaff.toStaff()));
   }
 
   /**
@@ -114,9 +114,10 @@ public class StaffService {
    *
    * @return A list of all active staff members.
    */
-  public List<Staff> getActiveStaff() {
+  public List<StaffDto> getActiveStaff() {
     return staffRepository.findAll().stream()
         .filter(staff -> !staff.isInactive())
+        .map(StaffDto::of)
         .collect(Collectors.toList());
   }
 
@@ -150,16 +151,14 @@ public class StaffService {
   /**
    * Updates a staff member in the database.
    *
-   * @param id           Of the staff member being updated.
    * @param updatedStaff Updated staff details.
    * @return The updated {@link Staff} member.
    */
-  public Staff updateStaff(int id, StaffDto updatedStaff) {
+  public StaffDto updateStaff(StaffDto updatedStaff) {
     // Check to see if that staff member exists, throw exception if not.
-    staffRepository.findById(id).orElseThrow(() -> new StaffNotFoundException(id));
+    staffRepository.findById(updatedStaff.getId())
+        .orElseThrow(() -> new StaffNotFoundException(updatedStaff.getId()));
     // If it exists, safe new staff information to that ID.
-    Staff staffToSave = updatedStaff.toStaff();
-    staffToSave.setId(id);
-    return staffRepository.save(staffToSave);
+    return StaffDto.of(staffRepository.save(updatedStaff.toStaff()));
   }
 }

--- a/backend/src/main/java/com/rota/api/dto/StaffDto.java
+++ b/backend/src/main/java/com/rota/api/dto/StaffDto.java
@@ -13,6 +13,9 @@ import lombok.Value;
 @Value
 @AllArgsConstructor
 public class StaffDto {
+  @ApiModelProperty(value = "Staff ID, ignored when creating new staff", required = false)
+  int id;
+
   @NotNull
   @ApiModelProperty(value = "First name", required = true)
   String firstName;
@@ -57,6 +60,7 @@ public class StaffDto {
    */
   public Staff toStaff() {
     return Staff.builder()
+        .id(id)
         .firstName(firstName)
         .surname(surname)
         .role(role)
@@ -68,5 +72,27 @@ public class StaffDto {
         .preferredDates(preferredDates)
         .email(email)
         .build();
+  }
+
+  /**
+   * Converts database Staff object to StaffDto.
+   * 
+   * @param staff Staff object
+   * @return converted StaffDto
+   */
+  public static StaffDto of(Staff staff) {
+    return new StaffDto(
+        staff.getId(),
+        staff.getFirstName(),
+        staff.getSurname(),
+        staff.getRole(),
+        staff.getStartDate(),
+        staff.getContractedHours(),
+        staff.getHourlyRate(),
+        staff.getJobTitle(),
+        staff.getPreferredDates(),
+        staff.isInactive(),
+        staff.getEmail()
+    );
   }
 }

--- a/backend/src/test/java/com/rota/api/StaffServiceTests.java
+++ b/backend/src/test/java/com/rota/api/StaffServiceTests.java
@@ -33,8 +33,8 @@ public class StaffServiceTests {
     MockitoAnnotations.initMocks(this);
   }
 
-  private final StaffDto validStaffDto =
-      new StaffDto("Initial", "Test", Role.USER, null, 0,
+  private final StaffDto invalidStaffDto =
+      new StaffDto(12301, "Initial", "Test", Role.USER, null, 0,
           0, "", "", false, "test@test.com");
 
   @Test
@@ -44,22 +44,22 @@ public class StaffServiceTests {
         .thenThrow(new StaffNotFoundException(invalidUserId));
 
     assertThrows(
-        StaffNotFoundException.class, () -> staffService.updateStaff(invalidUserId, validStaffDto));
+        StaffNotFoundException.class, () -> staffService.updateStaff(invalidStaffDto));
   }
 
   @Test
   public void updateStaff() {
     Staff initialStaffObject = new Staff();
     StaffDto updatedStaffDto =
-        new StaffDto("Updated", "User", Role.USER, null, 0,
+        new StaffDto(1, "Updated", "User", Role.USER, null, 0,
             0, "", "", false, "test@test.com");
     Staff updatedStaffObject = updatedStaffDto.toStaff();
 
     when(staffRepository.findById(1)).thenReturn(Optional.of(initialStaffObject));
     when(staffRepository.save(any(Staff.class))).thenReturn(updatedStaffObject);
 
-    Staff actualResult = staffService.updateStaff(1, updatedStaffDto);
+    StaffDto actualResult = staffService.updateStaff(updatedStaffDto);
 
-    assertThat(actualResult, is(equalTo(updatedStaffObject)));
+    assertThat(actualResult, is(equalTo(updatedStaffDto)));
   }
 }


### PR DESCRIPTION
Also simplified the endpoints as discussed.
All staff manipulations are now handled directly with /staff endpoint using different REST methods.
This will need to modified on the front end as well.

closes #156 