### PR TITLE
Feature/134 change delete functionality

### DIFF
--- a/backend/src/main/java/com/rota/api/StaffController.java
+++ b/backend/src/main/java/com/rota/api/StaffController.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -154,11 +155,11 @@ public class StaffController {
    * @param id staff id to remove.
    * @return An updated list of active staff members.
    */
-  @DeleteMapping("/staff")
+  @DeleteMapping("/staff/{id}")
   @ApiOperation(value = "Allows manager to remove a user with a given id and returns "
       + "an updated list of active users", authorizations = {@Authorization(value = "Bearer")})
   public List<StaffDto> removeStaffMember(
-      @RequestParam(name = "id", required = true)
+      @PathVariable(name = "id", required = true)
           int id
   ) {
     staffService.removeStaff(id);

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -27,9 +27,9 @@ public class StaffService {
 
   /**
    * Checks if the engagement has any overlap with the requested time frame.
-   * 
+   *
    * @param start start time
-   * @param end end time
+   * @param end   end time
    * @return true if engagement times have any overlap with requested times
    */
   private Predicate<Engagement> isEngagementBetween(Instant start, Instant end) {
@@ -82,9 +82,9 @@ public class StaffService {
    * Returns all engagements between start and end dates (inclusive).
    * Engagements that go through start or end times are truncated.
    * Both start and end dates are optional and can be left as null.
-   * 
+   *
    * @param start start date or null to get from the beginning
-   * @param end end date or null to get to the end
+   * @param end   end date or null to get to the end
    * @return All engagements between the two dates
    */
   public List<EngagementDto> getAllEngagementsBetween(Instant start, Instant end) {
@@ -97,14 +97,14 @@ public class StaffService {
 
   private Optional<Engagement> fromDto(EngagementDto engagement) {
     Optional<Staff> staffOptional = staffRepository.findById(engagement.getStaffId());
-    return staffOptional.map((Staff staff) -> 
-    Engagement
-        .builder()
-        .staff(staff)
-        .start(engagement.getStart())
-        .end(engagement.getEnd())
-        .type(engagement.getType())
-        .build()
+    return staffOptional.map((Staff staff) ->
+        Engagement
+            .builder()
+            .staff(staff)
+            .start(engagement.getStart())
+            .end(engagement.getEnd())
+            .type(engagement.getType())
+            .build()
     );
 
   }
@@ -172,7 +172,7 @@ public class StaffService {
   public Optional<Staff> findStaffByEmail(String email) {
     return staffRepository.findAll().stream()
         .filter(staff -> staff
-            .getEmail().isPresent() && staff.getEmail().get().equalsIgnoreCase(email))
+            .getEmail().filter(email::equalsIgnoreCase).isPresent())
         .findFirst();
   }
 

--- a/backend/src/main/java/com/rota/api/StaffService.java
+++ b/backend/src/main/java/com/rota/api/StaffService.java
@@ -156,6 +156,9 @@ public class StaffService {
     Optional<Staff> staffMember = staffRepository.findById(id);
     staffMember.ifPresent(staff -> {
       staff.setInactive(true);
+      staff.setFirstName("");
+      staff.setSurname("");
+      staff.setEmail(null);
       staffRepository.save(staff);
     });
   }
@@ -169,8 +172,7 @@ public class StaffService {
   public Optional<Staff> findStaffByEmail(String email) {
     return staffRepository.findAll().stream()
         .filter(staff -> staff
-            .getEmail()
-            .equalsIgnoreCase(email))
+            .getEmail().isPresent() && staff.getEmail().get().equalsIgnoreCase(email))
         .findFirst();
   }
 

--- a/backend/src/main/java/com/rota/api/dto/StaffDto.java
+++ b/backend/src/main/java/com/rota/api/dto/StaffDto.java
@@ -92,7 +92,7 @@ public class StaffDto {
         staff.getJobTitle(),
         staff.getPreferredDates(),
         staff.isInactive(),
-        staff.getEmail()
+        staff.getEmail().orElse("")
     );
   }
 }

--- a/backend/src/main/java/com/rota/database/orm/staff/Staff.java
+++ b/backend/src/main/java/com/rota/database/orm/staff/Staff.java
@@ -1,6 +1,7 @@
 package com.rota.database.orm.staff;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -15,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 @Data
 @Entity
@@ -56,5 +58,9 @@ public class Staff {
   @PreUpdate
   private void onPreUpdate() {
     this.setJobTitle(jobTitle.toLowerCase());
+  }
+
+  public Optional<String> getEmail() {
+    return Optional.ofNullable(email);
   }
 }

--- a/frontend/src/store/employeeSlice.ts
+++ b/frontend/src/store/employeeSlice.ts
@@ -20,9 +20,7 @@ const employeesAdapter = createEntityAdapter<Employee>({
   selectId: ({ id }) => id,
 });
 
-const EMPLOYEE_FETCH_URL = `${baseUrl}/staff`;
-const EMPLOYEE_DELETE_URL = `${baseUrl}/staff?id=`;
-const EMPLOYEE_CREATE_URL = `${baseUrl}/staff`;
+const EMPLOYEE_URL = `${baseUrl}/staff`
 
 export const employeeSlice = createSlice({
   name: 'employee',
@@ -53,7 +51,7 @@ export const fetchEmployee = (
   token: string | undefined
 ): AppThunk => async dispatch => {
   if (isManagerRole(await getRole(token))) {
-    updateFromPromise(get(EMPLOYEE_FETCH_URL, token), dispatch, set);
+    updateFromPromise(get(EMPLOYEE_URL, token), dispatch, set);
   }
 };
 
@@ -61,13 +59,13 @@ export const createEmployee = (
   request: CreateEmployeeRequest,
   token: string | undefined
 ): AppThunk => dispatch =>
-  updateFromPromise(post(EMPLOYEE_CREATE_URL, token, request), dispatch, add);
+  updateFromPromise(post(EMPLOYEE_URL, token, request), dispatch, add);
 
 export const deleteEmployee = (
   id: string,
   token: string | undefined
 ): AppThunk => dispatch =>
-  updateFromPromise(remove(EMPLOYEE_DELETE_URL + id, token), dispatch, set);
+  updateFromPromise(remove(`${EMPLOYEE_URL}/${id}`, token), dispatch, set);
 
 const { selectAll } = employeesAdapter.getSelectors<RootState>(
   ({ employee }) => employee

--- a/frontend/src/store/employeeSlice.ts
+++ b/frontend/src/store/employeeSlice.ts
@@ -20,7 +20,7 @@ const employeesAdapter = createEntityAdapter<Employee>({
   selectId: ({ id }) => id,
 });
 
-const EMPLOYEE_URL = `${baseUrl}/staff`
+const EMPLOYEE_URL = `${baseUrl}/staff`;
 
 export const employeeSlice = createSlice({
   name: 'employee',


### PR DESCRIPTION
### Changes
- Updated the `DELETE` endpoint in the controller to use a RESTful url
  - To delete user with ID of 1, you use `DELETE /staff/1`
  - This has been updated in the front-end.
- Since email is set to `null` on staff deletion, an optional is used for `getEmail()`.
