### PR TITLE
Deployment/heroku

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT -Dspring.profiles.active=prod $JAVA_OPTS -jar build/libs/*.jar 

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -Dspring.profiles.active=prod $JAVA_OPTS -jar build/libs/*.jar 
+web: java -Dserver.port=$PORT -Dspring.profiles.active=prod $JAVA_OPTS -jar build/libs/*.jar

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
 	implementation 'org.springframework.security:spring-security-config'
-  runtimeOnly 'mysql:mysql-connector-java'
+  	runtimeOnly 'mysql:mysql-connector-java'
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -11,6 +11,10 @@ group = 'com'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+bootRun {
+	args = ["--spring.profiles.active=${project.properties['profile'] ?: 'dev'}"]
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -55,6 +59,7 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-oauth2-resource-server'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
 	implementation 'org.springframework.security:spring-security-config'
+  runtimeOnly 'mysql:mysql-connector-java'
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=user
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,5 +1,2 @@
 spring.datasource.url=jdbc:${CLEARDB_DATABASE_URL}
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.security.oauth2.resourceserver.jwt.issuer-uri = https://rota-flex-101.eu.auth0.com/
-auth0.audience = rota-flex-api

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,5 +1,5 @@
-server.port = 8080
-spring.application.name = rotaflex
+spring.datasource.url=jdbc:${CLEARDB_DATABASE_URL}
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.security.oauth2.resourceserver.jwt.issuer-uri = https://rota-flex-101.eu.auth0.com/
 auth0.audience = rota-flex-api


### PR DESCRIPTION
- Split application properties
  - Shared properties stay in `application.properties`
  - Dev properties are in `application-dev.properties`
  - Prod properties are in `application-prod.properties`
  - `gradlew bootRun` defaults to using dev properties
    - Prod properties can be run using `gradlew bootRun -Pprofile=prod`
- Added mysql connector
