### PR TITLE
Deployment\Remove source map from production

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -5,3 +5,5 @@ REACT_APP_AUTH_CLIENT_ID=NqmZExdF9Q14mgi7p5o5RkPt338B2irO
 REACT_APP_AUTH_AUDIENCE=rota-flex-api
 REACT_APP_AUTH_CALLBACK_URI=https://rota-flex-101.herokuapp.com/callback
 REACT_APP_AUTH_SCOPE=openid profile email https://rota-flex-101.com/claims/email
+
+GENERATE_SOURCEMAP=false


### PR DESCRIPTION
Currently the source is shown in the production version. This is enabled by default to help with debugging, however this isn't needed at the moment.

This line _should_ remove the source from the production build.